### PR TITLE
fix: GitHubワークフローの権限設定を修正

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      admin: write
+      administration: write
     
     steps:
       - name: Checkout repository


### PR DESCRIPTION
- admin: write を administration: write に変更
- ブランチ保護ルールの適用に必要な権限を正しく設定